### PR TITLE
Fix URL-encoded filenames 

### DIFF
--- a/m3u-file-collector.py
+++ b/m3u-file-collector.py
@@ -3,6 +3,7 @@ from itertools import count
 import shutil
 import os
 import sys
+import urllib
 
 
 try :
@@ -29,7 +30,7 @@ try :
         for line in f :
                 line = line.strip()
                 if line and line[0] != '#' :
-                    files.append(line)
+                    files.append(urllib.unquote(line).decode('utf8'))
 except IOError :
     print ("File not found.")
     sys.exit(1)


### PR DESCRIPTION
M3U playlists sometimes have URL-encoded filenames, e.g. playlists exported from Amarok.  This PR fixes handling of special characters (e.g. spaces) in such filenames.