### PR TITLE
Strip `file://` URL scheme

### DIFF
--- a/m3u-file-collector.py
+++ b/m3u-file-collector.py
@@ -29,6 +29,9 @@ try :
     with open(m3ufile) as f:
         for line in f :
                 line = line.strip()
+                # Strip URL scheme
+                if line.startswith('file://'):
+                    line = line[len('file://'):]
                 if line and line[0] != '#' :
                     files.append(urllib.unquote(line).decode('utf8'))
 except IOError :


### PR DESCRIPTION
Some software exports local paths as URL's; this fixes handling of such playlists.